### PR TITLE
Allow overriding dev mode token protections in production

### DIFF
--- a/lib/sisjwt/sis_jwt_options.rb
+++ b/lib/sisjwt/sis_jwt_options.rb
@@ -15,7 +15,14 @@ module Sisjwt
 
     class << self
       def valid_token_type?(token_type)
-        [TOKEN_TYPE_V1, (TOKEN_TYPE_DEV unless production_env?)].compact.include?(token_type)
+        @allowed_tokens ||= begin
+          dev_token_override ||= ENV.fetch('SISJWT_UNSAFE_ALLOW_DEV_TOKEN_IN_PROD', "false") =~ /^\s*(y|yes|t|true|1)\s*$/i
+          [
+            TOKEN_TYPE_V1,
+            (TOKEN_TYPE_DEV if dev_token_override || !production_env?),
+          ].compact
+        end
+        @allowed_tokens.include?(token_type)
       end
 
       def current

--- a/lib/sisjwt/version.rb
+++ b/lib/sisjwt/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Sisjwt
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end


### PR DESCRIPTION
I could have sworn we did this in Vancouver... but I can't find it now.

This allows setting `$SISJWT_UNSAFE_ALLOW_DEV_TOKEN_IN_PROD = true` to allow the use of dev token even when the env is set to production.

I also made the required change to the feature kube here: https://github.com/tractionguest/guest-server/commit/b3ae080b2

We will need to bump the version in guest-server after this is merged