### PR TITLE
Add ArnInventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,29 @@ $ pbpaste | bundle exec bin/sisjwt verify --iss=sic --aud=sie - | jq .
 
 NOTE: The `lifetime` key will not be returned if running in a production environment.
 
+## ARN Inventory
+
+You can specify an ARN inventory that lists which KMS Key ARNs are allowed as issuers.  If an inventory file is specified then these key ARNs will be verified against the inventory and not allowed if there isn't an explicit match listed in the inventory file.
+
+You can control which section is read using the `SISJWT_ARN_MODE` environment variable, if not specified then it will default back to `RAILS_ENV`, or `development`.
+
+
+```yaml
+devkube:
+  sie:
+    - arn:a
+    - arn:b
+  sic:
+    - arn:c
+    - arn:d
+production:
+  sie:
+    - arn:1
+    - arn:2
+  sic:
+    - arn:3
+    - arn:4
+```
 
 ## Development
 

--- a/lib/sisjwt.rb
+++ b/lib/sisjwt.rb
@@ -13,4 +13,6 @@ module Sisjwt
   TOKEN_TYPE_V1 = 'SISKMS1.0'
 
   Error = Class.new(StandardError)
+  FileNotFoundError = Class.new(Error)
+  InventoryFileError = Class.new(Error)
 end

--- a/lib/sisjwt/arn_inventory.rb
+++ b/lib/sisjwt/arn_inventory.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Sisjwt
+  # An interface for reading / interacting with an ARN inventory file that can be
+  # provided by DevOps team to validate which ARNs are assigned to which issuers
+  class ArnInventory
+    def initialize
+      @inventory = {}
+    end
+
+    # @param path [string]
+    # @param env [string]
+    def add_from_config(path, env: nil)
+      path = Pathname.new(path)
+      raise FileNotFoundError(path) unless path.file?
+
+      env ||= ENV.fetch("RAILS_ENV", "development")
+      config_file = YAML.load(File.read(path)).with_indifferent_access
+
+      unless config_file.has_key?(env)
+        raise InventoryFileError("Could not find requested environment (#{env}) in inventory file #{path}")
+      end
+      unless config_file[env].is_a?(Hash)
+        raise InventoryFileError("Inventory file is malformed!")
+      end
+
+      @inventory = config_file[env]
+    end
+
+    # @return [boolean]
+    def empty?
+      @inventory.empty?
+    end
+
+    # @param issuer [string,symbol]
+    # @param arn [string]
+    # @return [boolean]
+    def valid_arn?(issuer, arn)
+      return false unless @inventory.has_key?(issuer)
+      @inventory[issuer].include?(arn)
+    end
+
+    # @param arn [string]
+    # @return [boolean]
+    def find_issuer(arn)
+      @inventory.each do |iss, arns|
+        return iss if arns.include?(arn)
+      end
+
+      nil
+    end
+  end
+end

--- a/lib/sisjwt/sis_jwt.rb
+++ b/lib/sisjwt/sis_jwt.rb
@@ -35,7 +35,7 @@ module Sisjwt
     def verify(token)
       logger.debug "SISJWT-verify: #{token}"
       payload, headers = decode_jwt(token)
-      VerificationResult.new(headers, payload).tap do |ret|
+      VerificationResult.new(headers, payload, options: options).tap do |ret|
         logger.debug("SISJWT-verifed: #{ret.inspect}")
       end
     rescue JWT::DecodeError => e

--- a/lib/sisjwt/sis_jwt_options.rb
+++ b/lib/sisjwt/sis_jwt_options.rb
@@ -9,7 +9,7 @@ module Sisjwt
 
     VALID_MODES = %i[sign verify].freeze
 
-    attr_reader :mode
+    attr_reader :mode, :arn_inventory
     attr_writer :exp, :iat, :key_alg, :key_id, :token_type
     attr_accessor :aws_region, :aws_profile, :token_lifetime, :iss, :aud
 
@@ -68,6 +68,7 @@ module Sisjwt
     # @param mode [Symbol] One of {VALID_MODES}.
     def initialize(mode: :sign)
       @mode = mode
+      @arn_inventory = ArnInventory.new
       raise ArgumentError, "invalid mode: #{mode}" unless VALID_MODES.include?(mode)
     end
 

--- a/lib/sisjwt/version.rb
+++ b/lib/sisjwt/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Sisjwt
-  VERSION = '0.2.0'
+  VERSION = '0.2.2'
 end

--- a/spec/sisjwt/arn_inventory_spec.rb
+++ b/spec/sisjwt/arn_inventory_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+RSpec.describe Sisjwt::ArnInventory do
+  let(:inventory_config_path) { "spec/support/fixtures/arn_inventory.yaml" }
+  let(:env) { :test }
+  let(:sie_arns) { %w(arn:A) }
+  let(:sic_arns) { %w(arn:C) }
+
+  describe '#add_from_config' do
+    context "env: test" do
+      before do
+        expect(subject).to be_empty
+        subject.add_from_config(inventory_config_path, env: env)
+        expect(subject).to_not be_empty
+      end
+
+      it 'loads inventory from expected section' do
+        sie_arns.each do |arn|
+          expect(subject.valid_arn?(:sie, arn)).to be_truthy, "Expected arn '#{arn}' to be present"
+        end
+        sic_arns.each do |arn|
+          expect(subject.valid_arn?(:sic, arn)).to be_truthy, "Expected arn '#{arn}' to be present"
+        end
+      end
+
+      it 'returns false if arn isnt in inventory' do
+        expect(subject.valid_arn?(:sie, sic_arns.sample)).to be_falsy
+        expect(subject.valid_arn?(:sic, sie_arns.sample)).to be_falsy
+      end
+
+      it 'allows strings for issuer' do
+        expect(subject.valid_arn?('sie', sie_arns.sample)).to be_truthy
+        expect(subject.valid_arn?('sic', sic_arns.sample)).to be_truthy
+      end
+    end
+
+    context "env: devkube" do
+      let(:env) { :devkube }
+      let(:sie_arns) { %w(arn:a arn:b) }
+      let(:sic_arns) { %w(arn:c arn:d) }
+
+      before do
+        expect(subject).to be_empty
+        subject.add_from_config(inventory_config_path, env: env)
+        expect(subject).to_not be_empty
+      end
+
+      it 'loads inventory from expected section' do
+        sie_arns.each do |arn|
+          expect(subject.valid_arn?(:sie, arn)).to be_truthy, "Expected arn '#{arn}' to be present"
+        end
+        sic_arns.each do |arn|
+          expect(subject.valid_arn?(:sic, arn)).to be_truthy, "Expected arn '#{arn}' to be present"
+        end
+      end
+    end
+  end
+
+  describe "#find_issuer" do
+    before do
+      expect(subject).to be_empty
+      subject.add_from_config(inventory_config_path, env: env)
+      expect(subject).to_not be_empty
+    end
+
+    it 'finds the correct issuer' do
+      expect(subject.find_issuer(sic_arns.sample)).to eq "sic"
+    end
+
+    it 'returns nil if issuer not in inventory' do
+      expect(subject.find_issuer("arn:missing")).to be_nil
+    end
+  end
+end

--- a/spec/support/fixtures/arn_inventory.yaml
+++ b/spec/support/fixtures/arn_inventory.yaml
@@ -1,0 +1,22 @@
+test:
+  sie:
+    - arn:A
+  sic:
+    - arn:C
+
+devkube:
+  sie:
+    - arn:a
+    - arn:b
+  sic:
+    - arn:c
+    - arn:d
+
+production:
+  sie:
+    - arn:1
+    - arn:2
+  sic:
+    - arn:3
+    - arn:4
+


### PR DESCRIPTION
Will allow DevOps to distribute a YAML file in our docker builds that contains
known valid ARNs for each business unit.

It is based on the rails DB config file (without ERB support at this time) so
that we can easily override which ARNs on the dev kubes.