### PR TITLE
HOTFIX: For breakage during refactoring

### DIFF
--- a/lib/sisjwt/command_line.rb
+++ b/lib/sisjwt/command_line.rb
@@ -57,7 +57,7 @@ module Sisjwt
     end
 
     def production?
-      jwt_opts.class.production_env?
+      Runtime.production_env?
     end
 
     # Transforms array like:

--- a/lib/sisjwt/sis_jwt_options.rb
+++ b/lib/sisjwt/sis_jwt_options.rb
@@ -95,7 +95,7 @@ module Sisjwt
     end
 
     def dev_token_in_prod?
-      self.class.production_env? && @token_type == TOKEN_TYPE_DEV
+      Runtime.production_env? && @token_type == TOKEN_TYPE_DEV
     end
 
     def production_token_type?

--- a/lib/sisjwt/version.rb
+++ b/lib/sisjwt/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Sisjwt
-  VERSION = '0.2.2'
+  VERSION = '0.2.3'
 end


### PR DESCRIPTION
`production_env?` has been moved to the `Runtime` helper class.

This would have been caught had we been running specs on GH.  I will get with DevOps to make sure we are doing this.