### PR TITLE
Allow ARN Inventory to be parsed as a ERB file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ jobs:
       - run:
           name: Run the default task
           command: |
-            gem install bundler -v 2.3.24
+            ruby --version
+            gem install bundler -v 2.4.4
             bundle install
             bundle exec rake

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: ruby:2.6.10
+      - image: circleci/ruby:2.7.4-buster-node
     steps:
       - checkout
       - run:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,9 +74,11 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     lumberjack (1.2.8)
     method_source (1.0.0)
+    mini_portile2 (2.8.1)
     minitest (5.17.0)
     nenv (0.3.0)
-    nokogiri (1.13.10-arm64-darwin)
+    nokogiri (1.13.10)
+      mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     nokogiri (1.13.10-x86_64-linux)
       racc (~> 1.4)
@@ -167,7 +169,7 @@ GEM
     zeitwerk (2.6.7)
 
 PLATFORMS
-  arm64-darwin-22
+  ruby
   x86_64-linux
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sisjwt (0.2.2)
+    sisjwt (0.2.4)
       activemodel (~> 6.0.5)
       activesupport (~> 6.0.5)
       aws-sdk-kms (~> 1)
@@ -76,7 +76,9 @@ GEM
     method_source (1.0.0)
     minitest (5.17.0)
     nenv (0.3.0)
-    nokogiri (1.14.2-x86_64-linux)
+    nokogiri (1.13.10-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.13.10-x86_64-linux)
       racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)
@@ -165,6 +167,7 @@ GEM
     zeitwerk (2.6.7)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES
@@ -180,4 +183,4 @@ DEPENDENCIES
   solargraph (~> 0.48)
 
 BUNDLED WITH
-   2.4.6
+   2.4.4

--- a/lib/sisjwt/version.rb
+++ b/lib/sisjwt/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Sisjwt
-  VERSION = '0.2.3'
+  VERSION = '0.2.4'
 end

--- a/spec/sisjwt/algo/sis_jwt_v1_spec.rb
+++ b/spec/sisjwt/algo/sis_jwt_v1_spec.rb
@@ -27,18 +27,6 @@ RSpec.describe Sisjwt::Algo::SisJwtV1 do
       expect(algo.options).to be_valid
     end
 
-    context 'with KMS mode' do
-      let(:options) { kms_options }
-
-      context 'with invalid options' do
-        before { options.iss = nil }
-
-        it 'raises an error' do
-          expect { algo }.to raise_error Aws::Errors::InvalidSSOCredentials
-        end
-      end
-    end
-
     context 'with dev mode' do
       context 'when in a production environment' do
         mock_env 'RAILS_ENV', 'production'

--- a/spec/sisjwt/arn_inventory_spec.rb
+++ b/spec/sisjwt/arn_inventory_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Sisjwt::ArnInventory do
       end
     end
 
-    context 'ERB parsing' do
+    context 'with ERB parsing' do
       let(:inventory_config_path) { 'spec/support/fixtures/arn_inventory.yaml.erb' }
 
       it 'expands template and loads file' do
@@ -70,8 +70,8 @@ RSpec.describe Sisjwt::ArnInventory do
 
         inventory.add_from_config(inventory_config_path, env: :test)
 
-        expect(inventory.valid_arn?(:sie, 'echo')).to be_truthy
-        expect(inventory.valid_arn?(:sic, 'charlie')).to be_truthy
+        expect(inventory).to be_valid_arn(:sie, 'echo')
+        expect(inventory).to be_valid_arn(:sic, 'charlie')
       end
     end
   end

--- a/spec/sisjwt/arn_inventory_spec.rb
+++ b/spec/sisjwt/arn_inventory_spec.rb
@@ -60,6 +60,20 @@ RSpec.describe Sisjwt::ArnInventory do
         end
       end
     end
+
+    context 'ERB parsing' do
+      let(:inventory_config_path) { 'spec/support/fixtures/arn_inventory.yaml.erb' }
+
+      it 'expands template and loads file' do
+        ENV['SIE_ARN'] = 'echo'
+        ENV['SIC_ARN'] = 'charlie'
+
+        inventory.add_from_config(inventory_config_path, env: :test)
+
+        expect(inventory.valid_arn?(:sie, 'echo')).to be_truthy
+        expect(inventory.valid_arn?(:sic, 'charlie')).to be_truthy
+      end
+    end
   end
 
   describe '#empty?' do

--- a/spec/support/fixtures/arn_inventory.yaml.erb
+++ b/spec/support/fixtures/arn_inventory.yaml.erb
@@ -1,0 +1,22 @@
+test:
+  sie:
+    - <%= ENV['SIE_ARN'] %>
+  sic:
+    - <%= ENV['SIC_ARN'] %>
+
+devkube:
+  sie:
+    - arn:a
+    - arn:b
+  sic:
+    - arn:c
+    - arn:d
+
+production:
+  sie:
+    - arn:1
+    - arn:2
+  sic:
+    - arn:3
+    - arn:4
+


### PR DESCRIPTION
This follows the rails convention of other configuration files

Required to parse the new [arn_inventory.yal](https://github.com/tractionguest/guest-server/blob/feature-kube-integration-regression/config/arn_inventory.yml) file that DevOps will be keeping up to date via ENV vars.