### PR TITLE
decode: case-insensitive headers

### DIFF
--- a/lib/sisjwt/case_insensitive_hash.rb
+++ b/lib/sisjwt/case_insensitive_hash.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Sisjwt
+  # An immutable {Hash} subclass where every key is a case-insensitive string.
+  class CaseInsensitiveHash < Hash
+    # @param src [Hash<#to_s, Object>, nil]
+    def initialize(src = nil)
+      super()
+      @keys = Hash(src).to_h { |k, _| [normalize_key(k), k] }.freeze
+      merge!(Hash(src).slice(*@keys.values))
+      freeze
+    end
+
+    def fetch(key, *args, &blk)
+      super(@keys[normalize_key(key)], *args, &blk)
+    end
+
+    def [](key)
+      fetch(key, nil)
+    end
+
+    def key?(key)
+      @keys.key?(normalize_key(key))
+    end
+
+    def ==(other)
+      return false unless other.is_a?(Hash) && size == other.size
+
+      other.each do |key, value|
+        return false unless key?(key) && self[key] == value
+      end
+
+      true
+    end
+
+    private
+
+    def normalize_key(key)
+      key.to_s.downcase
+    end
+  end
+end

--- a/lib/sisjwt/version.rb
+++ b/lib/sisjwt/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Sisjwt
-  VERSION = '0.2.4'
+  VERSION = '0.3.0-alpha1'
 end

--- a/spec/sisjwt/case_insensitive_hash_spec.rb
+++ b/spec/sisjwt/case_insensitive_hash_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+RSpec.describe Sisjwt::CaseInsensitiveHash do
+  context 'when empty' do
+    subject(:hash) { described_class.new }
+
+    it 'is empty' do
+      expect(hash).to be_empty
+      expect(hash.size).to eq 0
+    end
+  end
+
+  context 'with duplicate keys' do
+    subject(:hash) { described_class.new(src) }
+
+    let(:src) { { 'key' => 'lower', 'KeY' => 'MiXeD', 'KEY' => 'UPPER' } }
+
+    it 'only keeps the last entry' do
+      expect(hash.size).to eq 1
+      expect(hash.values.first).to eq 'UPPER'
+    end
+
+    describe '#fetch' do
+      it 'returns the same value for all capitalizations' do
+        src.each_key { |key| expect(hash.fetch(key)).to eq 'UPPER' }
+      end
+    end
+
+    describe '#[]' do
+      it 'returns the same value for all capitalizations' do
+        src.each_key { |key| expect(hash[key]).to eq 'UPPER' }
+      end
+    end
+
+    describe '#key?' do
+      it 'returns true for each key capitalization' do
+        src.each_key { |key| expect(hash).to be_key key }
+      end
+    end
+
+    describe '#keys' do
+      it 'returns the keys with their original capitalization' do
+        expect(hash.keys).to eq ['KEY']
+      end
+    end
+
+    describe '#==' do
+      context 'with another CaseInsensitiveHash' do
+        it { expect(hash).to eq described_class.new('key' => 'UPPER') }
+        it { expect(hash).to eq described_class.new('KeY' => 'UPPER') }
+        it { expect(hash).not_to eq described_class.new('KEY' => 'lower') }
+      end
+
+      context 'with a Hash' do
+        it { expect(hash).to eq('key' => 'UPPER') }
+        it { expect(hash).to eq('KeY' => 'UPPER') }
+        it { expect(hash).not_to eq('KEY' => 'lower') }
+      end
+
+      context 'with a string' do
+        it { expect(hash).not_to eq '{ "KEY" => "UPPER" }' }
+      end
+    end
+  end
+end

--- a/spec/sisjwt/sis_jwt_spec.rb
+++ b/spec/sisjwt/sis_jwt_spec.rb
@@ -215,7 +215,7 @@ RSpec.describe Sisjwt::SisJwt do
 
       it 'returns KMS verification context' do
         result = sis_jwt.verify(pseudo_token)
-        expect(result.headers).to be headers
+        expect(result.headers).to eq headers
         expect(result.payload).to be payload
       end
     end

--- a/spec/sisjwt/verification_result_spec.rb
+++ b/spec/sisjwt/verification_result_spec.rb
@@ -75,24 +75,40 @@ RSpec.describe Sisjwt::VerificationResult do
   describe '#add_allowed_aud' do
     it 'changes allowed_aud' do
       expect { result.add_allowed_aud(:test) }.to \
-        change(result, :allowed_aud).from([]).to([:test])
+        change(result, :allowed_aud).from([]).to(['test'])
     end
 
     it 'is included in to_h' do
       expect { result.add_allowed_aud(:test) }.to \
-        change(result, :to_h).to(include(allowed: include(aud: [:test])))
+        change(result, :to_h).to(include(allowed: include(aud: ['test'])))
+    end
+
+    context 'with a mixed-case payload' do
+      let(:aud) { 'MIXED_case' }
+
+      before { result.add_allowed_aud(:mixed_case) }
+
+      it { expect(result.errors.full_messages_for(:aud)).to be_empty }
     end
   end
 
   describe '#add_allowed_iss' do
     it 'changes allowed_iss' do
       expect { result.add_allowed_iss(:test) }.to \
-        change(result, :allowed_iss).from([]).to([:test])
+        change(result, :allowed_iss).from([]).to(['test'])
     end
 
     it 'is included in to_h' do
       expect { result.add_allowed_iss(:test) }.to \
-        change(result, :to_h).to(include(allowed: include(iss: [:test])))
+        change(result, :to_h).to(include(allowed: include(iss: ['test'])))
+    end
+
+    context 'with a mixed-case payload' do
+      let(:iss) { 'MIXED_case' }
+
+      before { result.add_allowed_iss(:mixed_case) }
+
+      it { expect(result.errors.full_messages_for(:iss)).to be_empty }
     end
   end
 end


### PR DESCRIPTION
### Description: ###

As a quality-of-life improvement, the SIW team has asked us to make this authentication scheme more permissive with respect to the capitalisation of the expected headers. Currently some are expected to be lowercase and some uppercase. Based on the [robustness principle](https://en.wikipedia.org/wiki/Robustness_principle), this is probably a good idea. 
