### PR TITLE
Handle Aws::KMS::Errors::NotFoundException

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sisjwt (0.3.0)
+    sisjwt (0.3.1)
       activemodel (~> 6.1.7, >= 6.1.7.3)
       activesupport (~> 6.1.7, >= 6.1.7.3)
       aws-sdk-kms (~> 1)

--- a/lib/sisjwt.rb
+++ b/lib/sisjwt.rb
@@ -14,5 +14,6 @@ module Sisjwt
 
   Error = Class.new(StandardError)
   FileNotFoundError = Class.new(Error)
+  KeyNotFoundError = Class.new(Error)
   InventoryFileError = Class.new(Error)
 end

--- a/lib/sisjwt/algo/sis_jwt_v1.rb
+++ b/lib/sisjwt/algo/sis_jwt_v1.rb
@@ -123,7 +123,7 @@ module Sisjwt
         kms_client.verify(params).signature_valid
         true
       rescue Aws::KMS::Errors::NotFoundException => e
-        raise KeyNotFoundError, e
+        raise KeyNotFoundError, "#{e}; key_id='#{params[:key_id]}'"
       rescue Aws::KMS::Errors::KMSInvalidSignatureException
         false
       end

--- a/lib/sisjwt/algo/sis_jwt_v1.rb
+++ b/lib/sisjwt/algo/sis_jwt_v1.rb
@@ -118,11 +118,12 @@ module Sisjwt
         logger.debug("kms_verify message(#{message.size}b)>>#{message}<< signature>>" \
                      "#{signature.size}<< alg>>#{signing_algorithm}<< key_id>>#{verification_key_id}<<")
         params = build_kms_params(message: message, signature: signature,
-                                  key_id: verification_key_id,
-                                  signing_algorithm: signing_algorithm)
+                                  key_id: verification_key_id, signing_algorithm: signing_algorithm)
 
         kms_client.verify(params).signature_valid
         true
+      rescue Aws::KMS::Errors::NotFoundException => e
+        raise KeyNotFoundError, e
       rescue Aws::KMS::Errors::KMSInvalidSignatureException
         false
       end

--- a/lib/sisjwt/sis_jwt.rb
+++ b/lib/sisjwt/sis_jwt.rb
@@ -38,9 +38,9 @@ module Sisjwt
       new_result(headers, payload).tap do |ret|
         logger.debug("SISJWT-verifed: #{ret.inspect}")
       end
-    rescue JWT::DecodeError => e
+    rescue JWT::DecodeError, KeyNotFoundError => e
       # We can rescue from this error and return a result
-      logger.error("[SISJWT-verify]: [#{e.class}]#{e}")
+      logger.error("[SISJWT-verify]: [#{e.class}] #{e}")
       VerificationResult.error(e.message)
     end
 

--- a/lib/sisjwt/version.rb
+++ b/lib/sisjwt/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Sisjwt
-  VERSION = '0.3.0'
+  VERSION = '0.3.1'
 end

--- a/spec/sisjwt/algo/sis_jwt_v1_spec.rb
+++ b/spec/sisjwt/algo/sis_jwt_v1_spec.rb
@@ -127,9 +127,9 @@ RSpec.describe Sisjwt::Algo::SisJwtV1 do
           algo.verify(data: data, signature: signature, verification_key: verification_key)
 
           expect(kms_double).to have_received(:verify).with(
-                                  key_id: key_id, message: data, message_type: 'RAW',
-                                  signature: signature, signing_algorithm: signing_algorithm
-                                )
+            key_id: key_id, message: data, message_type: 'RAW',
+            signature: signature, signing_algorithm: signing_algorithm
+          )
         end
       end
 

--- a/spec/sisjwt/algo/sis_jwt_v1_spec.rb
+++ b/spec/sisjwt/algo/sis_jwt_v1_spec.rb
@@ -116,18 +116,32 @@ RSpec.describe Sisjwt::Algo::SisJwtV1 do
       let(:kms_double) { instance_double(Aws::KMS::Client) }
       let(:verify_result) { Struct.new(:signature_valid).new }
 
-      before do
-        allow(Aws::KMS::Client).to receive(:new).and_return(kms_double)
-        allow(kms_double).to receive(:verify).and_return(verify_result)
+      before { allow(Aws::KMS::Client).to receive(:new).and_return(kms_double) }
+
+      context 'when it finds the key' do
+        before do
+          allow(kms_double).to receive(:verify).and_return(verify_result)
+        end
+
+        it 'calls KMS' do
+          algo.verify(data: data, signature: signature, verification_key: verification_key)
+
+          expect(kms_double).to have_received(:verify).with(
+                                  key_id: key_id, message: data, message_type: 'RAW',
+                                  signature: signature, signing_algorithm: signing_algorithm
+                                )
+        end
       end
 
-      it 'calls KMS' do
-        algo.verify(data: data, signature: signature, verification_key: verification_key)
+      context 'when it cannot finds the key' do
+        let(:err) { Aws::KMS::Errors::NotFoundException.new(nil, 'region name') }
 
-        expect(kms_double).to have_received(:verify).with(
-          key_id: key_id, message: data, message_type: 'RAW',
-          signature: signature, signing_algorithm: signing_algorithm
-        )
+        before { allow(kms_double).to receive(:verify).and_raise(err) }
+
+        it 'raises a KeyNotFoundError' do
+          expect { algo.verify(data: data, signature: signature, verification_key: verification_key) }.to \
+            raise_error(Sisjwt::KeyNotFoundError, 'region name')
+        end
       end
     end
 

--- a/spec/sisjwt/algo/sis_jwt_v1_spec.rb
+++ b/spec/sisjwt/algo/sis_jwt_v1_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe Sisjwt::Algo::SisJwtV1 do
 
         it 'raises a KeyNotFoundError' do
           expect { algo.verify(data: data, signature: signature, verification_key: verification_key) }.to \
-            raise_error(Sisjwt::KeyNotFoundError, 'region name')
+            raise_error(Sisjwt::KeyNotFoundError, "region name; key_id='#{key_id}'")
         end
       end
     end

--- a/spec/sisjwt/sis_jwt_spec.rb
+++ b/spec/sisjwt/sis_jwt_spec.rb
@@ -220,6 +220,25 @@ RSpec.describe Sisjwt::SisJwt do
       end
     end
 
+    context 'when AWS KMS is configured but the key cannot be found' do
+      let(:options) { kms_options }
+      let(:headers) { { 'AWS_ALG' => 'alg!', 'kid' => 'kid!' } }
+      let(:payload) { { 'data' => 'data' } }
+      let(:pseudo_token) { Sisjwt::SisJwt.new(Sisjwt::SisJwtOptions.defaults).encode({}) }
+      let(:kms_double) { instance_double(Aws::KMS::Client) }
+      let(:err) { Aws::KMS::Errors::NotFoundException.new(nil, 'unknown key') }
+
+      before do
+        allow(Aws::KMS::Client).to receive(:new).and_return(kms_double)
+        allow(kms_double).to receive(:verify).and_raise(err)
+      end
+
+      it 'returns an error' do
+        result = sis_jwt.verify(pseudo_token)
+        expect(result.errors.full_messages).to include 'unknown key'
+      end
+    end
+
     context 'when dev mode is configured' do
       let(:options) { dev_options }
       let(:token) { sis_jwt.encode(data) }

--- a/spec/sisjwt/sis_jwt_spec.rb
+++ b/spec/sisjwt/sis_jwt_spec.rb
@@ -224,7 +224,7 @@ RSpec.describe Sisjwt::SisJwt do
       let(:options) { kms_options }
       let(:headers) { { 'AWS_ALG' => 'alg!', 'kid' => 'kid!' } }
       let(:payload) { { 'data' => 'data' } }
-      let(:pseudo_token) { Sisjwt::SisJwt.new(Sisjwt::SisJwtOptions.defaults).encode({}) }
+      let(:pseudo_token) { described_class.new(Sisjwt::SisJwtOptions.defaults).encode({}) }
       let(:kms_double) { instance_double(Aws::KMS::Client) }
       let(:err) { Aws::KMS::Errors::NotFoundException.new(nil, 'unknown key') }
 

--- a/spec/sisjwt/sis_jwt_spec.rb
+++ b/spec/sisjwt/sis_jwt_spec.rb
@@ -235,7 +235,7 @@ RSpec.describe Sisjwt::SisJwt do
 
       it 'returns an error' do
         result = sis_jwt.verify(pseudo_token)
-        expect(result.errors.full_messages).to include 'unknown key'
+        expect(result.errors.full_messages).to include "unknown key; key_id=''"
       end
     end
 


### PR DESCRIPTION
### JIRA: ###

This PR explicitly catches `Aws::KMS::Errors::NotFoundException` errors, raised by the `aws-sdk-kms` gem. This is a runtime error that happens when a non-multiregion-key is used to sign a token across multiple AWS regions. Instead of resulting in an HTTP 500 error, it's better to return the error message in the JSON response.