### PR TITLE
Try multiple KMS key strategies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sisjwt (0.3.1)
+    sisjwt (0.3.2)
       activemodel (~> 6.1.7, >= 6.1.7.3)
       activesupport (~> 6.1.7, >= 6.1.7.3)
       aws-sdk-kms (~> 1)

--- a/lib/sisjwt.rb
+++ b/lib/sisjwt.rb
@@ -9,6 +9,7 @@ loader = Zeitwerk::Loader.for_gem
 loader.setup
 
 module Sisjwt
+  KEY_ID_ENV_NAME = 'SISJWT_KEY_ID'
   TOKEN_TYPE_DEV = 'SISKMSd'
   TOKEN_TYPE_V1 = 'SISKMS1.0'
 

--- a/lib/sisjwt/algo/key_strategies/as_given.rb
+++ b/lib/sisjwt/algo/key_strategies/as_given.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Sisjwt
+  module Algo
+    module KeyStrategies
+      # Try the key ID provided from the verification key.
+      class AsGiven < KeyStrategies::Base
+        def call(params)
+          kms_client.verify(params)
+        end
+      end
+    end
+  end
+end

--- a/lib/sisjwt/algo/key_strategies/base.rb
+++ b/lib/sisjwt/algo/key_strategies/base.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Sisjwt
+  module Algo
+    module KeyStrategies
+      # The base class for all strategies in this module. Each strategy is
+      # expected to return +nil+ if it chose not to run for some reason, return
+      # a {Aws::KMS::Types::VerifyResponse}, or forward any
+      # {Aws::KMS::Errors::NotFoundException} raised by {#kms_client}.
+      class Base
+        attr_reader :kms_client
+
+        def initialize(kms_client)
+          @kms_client = kms_client
+        end
+
+        # @return [Aws::KMS::Types::VerifyResponse,nil] The result of attempting
+        #   to verify the signature, or +nil+, if this strategy was unsuitable.
+        # @raises Aws::KMS::Errors::NotFoundException
+        def call(params)
+          raise NotImplementedError
+        end
+      end
+    end
+  end
+end

--- a/lib/sisjwt/algo/key_strategies/env_key.rb
+++ b/lib/sisjwt/algo/key_strategies/env_key.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Sisjwt
+  module Algo
+    module KeyStrategies
+      # Try the key provided by this app's environment.
+      # @see KEY_ID_ENV_NAME
+      class EnvKey < KeyStrategies::Base
+        def call(params)
+          return nil unless env_key_id && env_key_id != params[:key_id]
+
+          kms_client.verify(params.merge(key_id: env_key_id))
+        end
+
+        private
+
+        def env_key_id
+          ENV.fetch(KEY_ID_ENV_NAME, nil)
+        end
+      end
+    end
+  end
+end

--- a/lib/sisjwt/algo/key_strategies/swap_region.rb
+++ b/lib/sisjwt/algo/key_strategies/swap_region.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Sisjwt
+  module Algo
+    module KeyStrategies
+      # It's possible that the given key exists both in the foreign region and
+      # this region, so try modifying the region-portion of the given key ID.
+      class SwapRegion < KeyStrategies::Base
+        def call(params)
+          swapped_key_id = swap_key_id(params[:key_id])
+          return nil unless swapped_key_id && swapped_key_id != params[:key_id]
+
+          kms_client.verify(params.merge(key_id: swapped_key_id))
+        end
+
+        private
+
+        def swap_region(key_id)
+          return nil unless key_id.start_with?('arn:aws:kms:')
+
+          parts = key_id.split(':')
+          [parts[0..2], kms_client.config.region, parts[4..]].flatten.join(':')
+        end
+      end
+    end
+  end
+end

--- a/lib/sisjwt/algo/key_strategies/swap_region.rb
+++ b/lib/sisjwt/algo/key_strategies/swap_region.rb
@@ -7,7 +7,7 @@ module Sisjwt
       # this region, so try modifying the region-portion of the given key ID.
       class SwapRegion < KeyStrategies::Base
         def call(params)
-          swapped_key_id = swap_key_id(params[:key_id])
+          swapped_key_id = swap_region(params[:key_id])
           return nil unless swapped_key_id && swapped_key_id != params[:key_id]
 
           kms_client.verify(params.merge(key_id: swapped_key_id))

--- a/lib/sisjwt/algo/kms_verify.rb
+++ b/lib/sisjwt/algo/kms_verify.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Sisjwt
+  module Algo
+    # With Amazon KMS's strict rules about sharing keys across AWS regional
+    # boundaries, and the complexity of "multi-region keys," it's apparently not
+    # always trivial to know the ARN of the correct key to use to verify the
+    # signature of a signed JWT.
+    #
+    # This service iterates through several strategies, returning the result of
+    # the first that works, or raising {KeyNotFoundError} if none do.
+    class KmsVerify
+      DEFAULT_STRATEGIES = [KeyStrategies::AsGiven,
+                            KeyStrategies::SwapRegion,
+                            KeyStrategies::EnvKey].freeze
+
+      attr_reader :kms_client, :strategies
+
+      def initialize(kms_client, strategies: DEFAULT_STRATEGIES)
+        @kms_client = kms_client
+        @strategies = strategies
+      end
+
+      def call(params)
+        iterate_strategies(params) || raise(KeyNotFoundError, params[:key_id])
+      end
+
+      private
+
+      def iterate_strategies(params)
+        strategies.lazy.filter_map { execute(_1, params) }.first
+      end
+
+      def execute(klass, params)
+        klass.new(kms_client).call(params)
+      rescue Aws::KMS::Errors::NotFoundException
+        nil
+      end
+    end
+  end
+end

--- a/lib/sisjwt/algo/kms_verify.rb
+++ b/lib/sisjwt/algo/kms_verify.rb
@@ -22,7 +22,7 @@ module Sisjwt
       end
 
       def call(params)
-        iterate_strategies(params) || raise(KeyNotFoundError, params[:key_id])
+        iterate_strategies(params) || raise_key_error(params)
       end
 
       private
@@ -35,6 +35,10 @@ module Sisjwt
         klass.new(kms_client).call(params)
       rescue Aws::KMS::Errors::NotFoundException
         nil
+      end
+
+      def raise_key_error(params)
+        raise KeyNotFoundError, "key_id not found: '#{params[:key_id]}'"
       end
     end
   end

--- a/lib/sisjwt/algo/sis_jwt_v1.rb
+++ b/lib/sisjwt/algo/sis_jwt_v1.rb
@@ -120,7 +120,7 @@ module Sisjwt
         params = build_kms_params(message: message, signature: signature,
                                   key_id: verification_key_id, signing_algorithm: signing_algorithm)
 
-        kms_client.verify(params).signature_valid
+        KmsVerify.new(kms_client).call(params).signature_valid
         true
       rescue Aws::KMS::Errors::NotFoundException => e
         raise KeyNotFoundError, "#{e}; key_id='#{params[:key_id]}'"

--- a/lib/sisjwt/algo/sis_jwt_v1.rb
+++ b/lib/sisjwt/algo/sis_jwt_v1.rb
@@ -122,8 +122,6 @@ module Sisjwt
 
         KmsVerify.new(kms_client).call(params).signature_valid
         true
-      rescue Aws::KMS::Errors::NotFoundException => e
-        raise KeyNotFoundError, "#{e}; key_id='#{params[:key_id]}'"
       rescue Aws::KMS::Errors::KMSInvalidSignatureException
         false
       end

--- a/lib/sisjwt/sis_jwt_options.rb
+++ b/lib/sisjwt/sis_jwt_options.rb
@@ -38,7 +38,7 @@ module Sisjwt
       def assign_env_options(opts)
         opts.aws_profile = Runtime.aws_profile
         opts.aws_region = ENV.fetch('AWS_REGION', 'us-west-2')
-        opts.key_id = ENV.fetch('SISJWT_KEY_ID', nil)
+        opts.key_id = ENV.fetch(KEY_ID_ENV_NAME, nil)
         opts.key_alg = ENV.fetch('SISJWT_KEY_ALG', 'RSASSA_PKCS1_V1_5_SHA_256')
         opts.iss = ENV.fetch('SISJWT_ISS', 'SISi')
         opts.aud = ENV.fetch('SISJWT_AUD', 'SISa')

--- a/lib/sisjwt/version.rb
+++ b/lib/sisjwt/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Sisjwt
-  VERSION = '0.3.1'
+  VERSION = '0.3.2'
 end

--- a/spec/sisjwt/algo/sis_jwt_v1_spec.rb
+++ b/spec/sisjwt/algo/sis_jwt_v1_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe Sisjwt::Algo::SisJwtV1 do
 
         it 'raises a KeyNotFoundError' do
           expect { algo.verify(data: data, signature: signature, verification_key: verification_key) }.to \
-            raise_error(Sisjwt::KeyNotFoundError, "region name; key_id='#{key_id}'")
+            raise_error(Sisjwt::KeyNotFoundError, "key_id not found: '#{key_id}'")
         end
       end
     end

--- a/spec/sisjwt/sis_jwt_options_spec.rb
+++ b/spec/sisjwt/sis_jwt_options_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe Sisjwt::SisJwtOptions do
       it { expect(options.aws_region).to eq 'testToken' }
     end
 
-    context 'when SISJWT_KEY_ID=testToken' do
-      mock_env 'SISJWT_KEY_ID', 'testToken'
+    context "when #{Sisjwt::KEY_ID_ENV_NAME}=testToken" do
+      mock_env Sisjwt::KEY_ID_ENV_NAME, 'testToken'
       mock_kms configured: true
 
       it { expect(options.key_id).to eq 'testToken' }
@@ -82,8 +82,8 @@ RSpec.describe Sisjwt::SisJwtOptions do
         end
       end
 
-      context 'when SISJWT_KEY_ID is unset' do
-        mock_env 'SISJWT_KEY_ID', nil
+      context "when #{Sisjwt::KEY_ID_ENV_NAME} is unset" do
+        mock_env Sisjwt::KEY_ID_ENV_NAME, nil
         mock_kms configured: true
 
         it "key_id defaults to ''" do

--- a/spec/sisjwt/sis_jwt_spec.rb
+++ b/spec/sisjwt/sis_jwt_spec.rb
@@ -235,7 +235,7 @@ RSpec.describe Sisjwt::SisJwt do
 
       it 'returns an error' do
         result = sis_jwt.verify(pseudo_token)
-        expect(result.errors.full_messages).to include "unknown key; key_id=''"
+        expect(result.errors.full_messages).to include "key_id not found: ''"
       end
     end
 


### PR DESCRIPTION
### JIRA: ###

We're having a lot of difficulty in ensuring the correct ARN for KMS keys is provided when crossing AWS regional boundaries. This PR introduces a strategy that will try multiple fallback keys in the event that KMS raises a `Aws::KMS::Errors::NotFoundException`.