### PR TITLE
Fixes undefined variable

### DIFF
--- a/lib/sisjwt/algo/sis_jwt_v1.rb
+++ b/lib/sisjwt/algo/sis_jwt_v1.rb
@@ -58,7 +58,8 @@ module Sisjwt
 
         if options.kms_configured?
           logger.debug do
-            File.binwrite('token_intercepted.sig', signature)
+            file_name = 'token_intercepted.sig'
+            File.binwrite(file_name, signature)
             "[#{alg}] verify-kms2: Writing #{file_name}: #{signature.size} bytes"
           end
           kms_verify(data, signature, aws_alg, key_arn)

--- a/lib/sisjwt/version.rb
+++ b/lib/sisjwt/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Sisjwt
-  VERSION = '0.4.2'
+  VERSION = '0.4.3'
 end


### PR DESCRIPTION
Fix undefined file_name variable in debug logging

  Fixed a bug in lib/sisjwt/algo/sis_jwt_v1.rb where the variable file_name was referenced but never defined in the debug logging block.

  Before:
  logger.debug do
    File.binwrite('token_intercepted.sig', signature)
    "[#{alg}] verify-kms2: Writing #{file_name}: #{signature.size} bytes"  # NameError
  end

  After:
  logger.debug do
    file_name = 'token_intercepted.sig'
    File.binwrite(file_name, signature)
    "[#{alg}] verify-kms2: Writing #{file_name}: #{signature.size} bytes"
  end

  This would cause a NameError when KMS verification ran with debug logging enabled.
